### PR TITLE
체크박스 컴포넌트 완성, 버튼 컴포넌트 form 하위로 이동후 인덱싱부분 타이틀 추가

### DIFF
--- a/packages/chakra-ui-styled/src/components/form/button/Button.stories.tsx
+++ b/packages/chakra-ui-styled/src/components/form/button/Button.stories.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import Button, { ButtonProps } from './Button';
 
 export default {
-  title: 'chakra-ui-styled/components/button',
+  title: 'chakra-ui-styled/components/form/button',
   component: Button,
   parameters: { controls: { expanded: true } },
 
@@ -33,11 +33,14 @@ export const ButtonIndex = (args: ButtonProps) => {
   const btnText: string = 'Button';
   return (
     <div style={{ display: 'flex', gap: '8px', flexDirection: 'column' }}>
-      <h2>Button</h2>
+      <h1>Button</h1>
 
+      <h2>Button Demo</h2>
       <div>
         <Button {...args} />
       </div>
+
+      <h2>Button Index</h2>
       <BtnBox>
         <Button leftIcon="CkReact" rightIcon="CkReact" size="lg" colorScheme="blue" text={btnText} />
         <Button leftIcon="CkReact" rightIcon="CkReact" size="md" colorScheme="blue" text={btnText} />

--- a/packages/chakra-ui-styled/src/components/form/button/Button.tsx
+++ b/packages/chakra-ui-styled/src/components/form/button/Button.tsx
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { TextComponent } from '../../foundation/typography/Text.styled';
+import { TextComponent } from '../../../foundation/typography/Text.styled';
 
 export interface ButtonProps {
   size: 'lg' | 'md' | 'sm' | 'xs';
@@ -212,8 +212,8 @@ const StyleButton = styled.button<ButtonProps>`
       : variant === 'solid'
         ? css`
             color: ${colorScheme === 'gray' || colorScheme === 'yellow'
-              ? theme.color.gray[800]
-              : theme.color.white.white};
+            ? theme.color.gray[800]
+            : theme.color.white.white};
             background-color: ${getColor(colorScheme).enabled};
 
             &:hover {

--- a/packages/chakra-ui-styled/src/components/form/checkbox/Checbok.stories.tsx
+++ b/packages/chakra-ui-styled/src/components/form/checkbox/Checbok.stories.tsx
@@ -1,0 +1,181 @@
+import styled from 'styled-components';
+import Checkbox, { CheckboxProps } from './Checkbox';
+
+
+export default {
+  title: 'chakra-ui-styled/components/form/checkbox',
+  component: Checkbox,
+  parameters: { controls: { expanded: true } },
+
+  argTypes: {
+    text: { control: { type: 'text' } },
+    size: { control: { type: 'select' } },
+    colorScheme: { control: { type: 'select' } },
+    isChecked: { control: { type: 'boolean' } },
+    isDisabled: { control: { type: 'boolean' } },
+  },
+  args: {
+    text: '체크대상텍스트',
+    size: 'md',
+    colorScheme: 'blue',
+    isChecked: true,
+    isDisabled: false,
+    isIndeterminate: false
+  }
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 60px;
+`;
+const CheckboxGroup = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  flex: 1 0 30%;
+  gap: 20px 20px;
+`;
+const colorSchemeIndex = ['blue', 'teal', 'green', 'cyan', 'purple', 'pink']
+
+export const CheckboxIndex = (args: CheckboxProps) => {
+  const chkText: string = 'Checkbox Label';
+  return (
+    <Wrapper>
+      <h1>Checkbox</h1>
+      <h2>Checkbox Demo</h2>
+      <div>
+        <Checkbox {...args} />
+      </div>
+
+      <h2>Checkbox Index</h2>
+      <CheckboxGroup>
+        <Checkbox size="sm" colorScheme="blue" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="blue" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="blue" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="blue" isChecked={true} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="blue" isChecked={true} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="blue" isChecked={true} isDisabled={false} isIndeterminate={false} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="blue" isChecked={true} isDisabled={false} isIndeterminate={true} text={chkText} />
+        <Checkbox size="md" colorScheme="blue" isChecked={true} isDisabled={false} isIndeterminate={true} text={chkText} />
+        <Checkbox size="lg" colorScheme="blue" isChecked={true} isDisabled={false} isIndeterminate={true} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="blue" isChecked={false} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="blue" isChecked={false} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="blue" isChecked={false} isDisabled={true} isIndeterminate={false} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="blue" isChecked={true} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="blue" isChecked={true} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="blue" isChecked={true} isDisabled={true} isIndeterminate={false} text={chkText} />
+      </CheckboxGroup>
+      <CheckboxGroup>
+        <Checkbox size="sm" colorScheme="teal" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="teal" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="teal" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="teal" isChecked={true} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="teal" isChecked={true} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="teal" isChecked={true} isDisabled={false} isIndeterminate={false} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="teal" isChecked={true} isDisabled={false} isIndeterminate={true} text={chkText} />
+        <Checkbox size="md" colorScheme="teal" isChecked={true} isDisabled={false} isIndeterminate={true} text={chkText} />
+        <Checkbox size="lg" colorScheme="teal" isChecked={true} isDisabled={false} isIndeterminate={true} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="teal" isChecked={false} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="teal" isChecked={false} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="teal" isChecked={false} isDisabled={true} isIndeterminate={false} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="teal" isChecked={true} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="teal" isChecked={true} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="teal" isChecked={true} isDisabled={true} isIndeterminate={false} text={chkText} />
+      </CheckboxGroup>
+      <CheckboxGroup>
+        <Checkbox size="sm" colorScheme="green" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="green" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="green" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="green" isChecked={true} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="green" isChecked={true} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="green" isChecked={true} isDisabled={false} isIndeterminate={false} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="green" isChecked={true} isDisabled={false} isIndeterminate={true} text={chkText} />
+        <Checkbox size="md" colorScheme="green" isChecked={true} isDisabled={false} isIndeterminate={true} text={chkText} />
+        <Checkbox size="lg" colorScheme="green" isChecked={true} isDisabled={false} isIndeterminate={true} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="green" isChecked={false} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="green" isChecked={false} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="green" isChecked={false} isDisabled={true} isIndeterminate={false} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="green" isChecked={true} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="green" isChecked={true} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="green" isChecked={true} isDisabled={true} isIndeterminate={false} text={chkText} />
+      </CheckboxGroup>
+      <CheckboxGroup>
+        <Checkbox size="sm" colorScheme="cyan" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="cyan" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="cyan" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="cyan" isChecked={true} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="cyan" isChecked={true} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="cyan" isChecked={true} isDisabled={false} isIndeterminate={false} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="cyan" isChecked={true} isDisabled={false} isIndeterminate={true} text={chkText} />
+        <Checkbox size="md" colorScheme="cyan" isChecked={true} isDisabled={false} isIndeterminate={true} text={chkText} />
+        <Checkbox size="lg" colorScheme="cyan" isChecked={true} isDisabled={false} isIndeterminate={true} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="cyan" isChecked={false} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="cyan" isChecked={false} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="cyan" isChecked={false} isDisabled={true} isIndeterminate={false} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="cyan" isChecked={true} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="cyan" isChecked={true} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="cyan" isChecked={true} isDisabled={true} isIndeterminate={false} text={chkText} />
+      </CheckboxGroup>
+      <CheckboxGroup>
+        <Checkbox size="sm" colorScheme="purple" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="purple" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="purple" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="purple" isChecked={true} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="purple" isChecked={true} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="purple" isChecked={true} isDisabled={false} isIndeterminate={false} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="purple" isChecked={true} isDisabled={false} isIndeterminate={true} text={chkText} />
+        <Checkbox size="md" colorScheme="purple" isChecked={true} isDisabled={false} isIndeterminate={true} text={chkText} />
+        <Checkbox size="lg" colorScheme="purple" isChecked={true} isDisabled={false} isIndeterminate={true} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="purple" isChecked={false} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="purple" isChecked={false} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="purple" isChecked={false} isDisabled={true} isIndeterminate={false} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="purple" isChecked={true} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="purple" isChecked={true} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="purple" isChecked={true} isDisabled={true} isIndeterminate={false} text={chkText} />
+      </CheckboxGroup>
+      <CheckboxGroup>
+        <Checkbox size="sm" colorScheme="pink" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="pink" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="pink" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="pink" isChecked={true} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="pink" isChecked={true} isDisabled={false} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="pink" isChecked={true} isDisabled={false} isIndeterminate={false} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="pink" isChecked={true} isDisabled={false} isIndeterminate={true} text={chkText} />
+        <Checkbox size="md" colorScheme="pink" isChecked={true} isDisabled={false} isIndeterminate={true} text={chkText} />
+        <Checkbox size="lg" colorScheme="pink" isChecked={true} isDisabled={false} isIndeterminate={true} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="pink" isChecked={false} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="pink" isChecked={false} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="pink" isChecked={false} isDisabled={true} isIndeterminate={false} text={chkText} />
+
+        <Checkbox size="sm" colorScheme="pink" isChecked={true} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="md" colorScheme="pink" isChecked={true} isDisabled={true} isIndeterminate={false} text={chkText} />
+        <Checkbox size="lg" colorScheme="pink" isChecked={true} isDisabled={true} isIndeterminate={false} text={chkText} />
+      </CheckboxGroup>
+
+    </Wrapper>
+  );
+};
+CheckboxIndex.storyName = 'Checkbox';

--- a/packages/chakra-ui-styled/src/components/form/checkbox/Checkbox.tsx
+++ b/packages/chakra-ui-styled/src/components/form/checkbox/Checkbox.tsx
@@ -1,0 +1,178 @@
+import styled, { css } from 'styled-components';
+
+export interface CheckboxProps {
+  size: 'sm' | 'md' | 'lg';
+  colorScheme: 'blue' | 'teal' | 'green' | 'cyan' | 'purple' | 'pink';
+  isChecked?: boolean;
+  isDisabled?: boolean;
+  isIndeterminate?: boolean;
+  // Indeterminate는 체크를 했다는 전제조건에서만 나올 수 있음, isDisabled가 true이면 Indeterminate는 자동으로 해제, 우선 배제하고 작업진행
+  text: string;
+}
+const checkboxSize = { sm: 12, md: 16, lg: 20, };
+const iconSize = { sm: 8, md: 12, lg: 16, };
+// 기본색상
+const getColor = (colorScheme: string) => css`
+  ${({ theme }) => {
+    switch (colorScheme) {
+      case 'blue':
+        return theme.color.blue[500];
+      case 'teal':
+        return theme.color.teal[500];
+      case 'green':
+        return theme.color.green[500];
+      case 'cyan':
+        return theme.color.cyan[500];
+      case 'purple':
+        return theme.color.purple[500];
+      case 'pink':
+        return theme.color.pink[500];
+      case 'gray':
+        return theme.color.gray[500];
+      default:
+        return theme.color.blue[500];
+    }
+  }}
+`;
+// label 사이즈 설정 했을 때 label의 왼쪽여백 조정
+const getLabelPadding = (size: string) => css`
+  ${({ theme }) => {
+    switch (size) {
+      case 'sm':
+        return theme.spacing[5];
+      case 'md':
+        return theme.spacing[6];
+      case 'lg':
+        return theme.spacing[7];
+      default:
+        return theme.spacing[6];
+    }
+  }}
+`;
+const CheckboxForm = styled.input.attrs({ type: "checkbox" })`
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+  height: 0;
+  width: 0;
+  
+  &:checked ~ span::after {
+    display: flex;
+  }
+`;
+const Label = styled.label<CheckboxProps>`
+  flex: 1 0 30%;
+  display: flex;
+  align-items: center;
+  position: relative;
+  padding: 0 0 0 ${({ size }) => getLabelPadding(size)};
+
+  // & input:checked ~ span::after {
+  //   display: flex;
+  // }
+
+  & span {
+    box-sizing: border-box;
+    position: absolute;
+    top: 50%;
+    left: 0;
+    transform: translate(0, -50%);
+    width: ${({ size }) => checkboxSize[size]}px;
+    height: ${({ size }) => checkboxSize[size]}px;
+    border-radius: 2px;
+    text-align: center;
+
+    &::after { 
+      position: absolute;
+      font-size: ${({ size }) => iconSize[size]}px;
+      width: inherit;
+      height: inherit;
+      top: inherit;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+
+    ${({ isChecked, isDisabled, isIndeterminate, colorScheme, theme }) => {
+    switch (true) {
+      case (isChecked == true):
+        if (isDisabled) { // 체크되고 비활성화
+          // if (isIndeterminate) { // isIndeterminate 설정되면 isDisabled = false;로 바꾸고 -뜨게하는 법?
+          //   isDisabled = false;
+          //   return
+          // } 
+          return css`
+              background-color: ${theme.color.gray[200]};
+              border: none;
+              &::after {
+                content: '✔';
+                color: ${theme.color.gray[500]};
+              }
+            `;
+        } else { // 체크되고 활성화
+          if (isIndeterminate) { // isIndeterminate 설정되면 -아이콘
+            return css`
+              background-color: ${getColor(colorScheme)};
+              border: 1px solid ${getColor(colorScheme)};
+              &::after {
+                content: '-';
+                color: ${theme.color.white.white};
+                transform: translate(-50%, -60%);
+              }
+            `;
+          }
+          return css`
+              background-color: ${getColor(colorScheme)};
+              border: 1px solid ${getColor(colorScheme)};
+              &::after {
+                content: '✔';
+                color: ${theme.color.white.white};
+              }
+            `;
+        };
+      case (isChecked == false):
+        if (isDisabled) {// 체크안되고 비활성화
+          return css`
+              background-color: ${theme.color.gray[100]};
+              border: none;
+              &::after {
+                content: '';
+              }
+            `;
+        } else { // 체크안되고 활성화
+          // if (isIndeterminate) { // isIndeterminate 설정되면 isDisabled = true;로 바꾸고 -뜨게하는 법?
+          //   isChecked = true;
+          //   return css`
+          //     background-color: ${getColor(colorScheme)};
+          //     border: 1px solid ${getColor(colorScheme)};
+          //     &::after {
+          //       content: '-';
+          //       color: ${theme.color.white.white};
+          //       transform: translate(-50%, -60%);
+          //     }
+          //   `;
+          // }
+          return css`
+              background-color: none;
+              border: 2px solid ${theme.color.gray[200]};
+              &::after {
+                content: '';
+              }
+            `;
+        }
+    }
+  }
+  }}
+`;
+const Checkbox = ({ size = 'md', isChecked = true, isDisabled = false, isIndeterminate = false, colorScheme, text }: CheckboxProps) => {
+  return (
+    <Label size={size} colorScheme={colorScheme} isChecked={isChecked} isDisabled={isDisabled} isIndeterminate={isIndeterminate} text="" >
+      <CheckboxForm />
+      <span />
+      {text}
+    </Label>
+  );
+};
+export default Checkbox;

--- a/packages/chakra-ui-styled/src/components/form/checkbox/icoCheckedGray.svg
+++ b/packages/chakra-ui-styled/src/components/form/checkbox/icoCheckedGray.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.95166 8.85384L6.28499 11.9788L12.9517 3.64551" stroke="#718096" stroke-width="2" stroke-linejoin="round"/>
+</svg>

--- a/packages/chakra-ui-styled/src/components/form/checkbox/icoCheckedWhite.svg
+++ b/packages/chakra-ui-styled/src/components/form/checkbox/icoCheckedWhite.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.46362 6.5884L4.79696 8.7759L9.46362 2.94257" stroke="#fff" stroke-width="1.5" stroke-linejoin="round"/>
+</svg>

--- a/packages/chakra-ui-styled/src/components/form/checkbox/icoIndeterminate.svg
+++ b/packages/chakra-ui-styled/src/components/form/checkbox/icoIndeterminate.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <line x1="4.5" y1="8" x2="11.5" y2="8" stroke="white" stroke-width="2" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
# 제목

체크박스 컴포넌트 완성, 버튼 컴포넌트 form 하위로 이동후 인덱싱부분 타이틀 추가

## 변경 사항

- 완성된 button component를  components/form 하위로 이동
(컴포넌트양이 방대해질 경우 대비 카테고리 분류시도)
- button component 내 스토리북 미리보기 화면에 h1, h2 태그 추가
- checkbox 또한 components/form 하위에 생성하여 인덱싱 완성 

## 리뷰어 참고 사항

1. 경우의 수 이슈
체크박스의 상황 상 3종(isChecked?: boolean;  isDisabled?: boolean;  isIndeterminate?: boolean;)의 boolean이 시각화에 큰 영향을 줍니다. 체크여부와 비활성화는 구성하는데 문제가 없었으나, 불확실을 표시하는 Indeterminate 부분구현이 어렵습니다.
  isChecked=true isDisabled=false isIndeterminate=false인 상태에서 isIndeterminate=true일 경우는 구현완료
  isChecked=false isDisabled=false isIndeterminate=false인 상태에서 isIndeterminate=true일 경우 isChecked=true가 자동으로 반영되어야 함. 스토리북 콘솔에서 구현이 안됨
  isChecked=true isDisabled=true isIndeterminate=false인 상태에서 isIndeterminate=true일 경우 isDisabled=false가 자동으로 반영(서로 토글)되어야 함. 스토리북 콘솔에서 구현이 안됨

2. svg 이슈
css의 가상요소인 ::before, ::after에 content 속성에는 url을 통해서 svg를 넣을 수 있는데, 여기에선 반영이 안됩니다.
웃음님이 슬랙에 공유해주시는 리액트에서 svg 적용하는 두가지 방법(이미지태그, 컴포넌트화) 둘다 적용해 보았는데 잘 모르겠습니다. 불러오지를 못해요. 그래서 png로 바꾸어 삽인해보았는데도 안됩니다. 그래서 다시 svg 인라인 코드를 직접 삽입후 구현해보려했는데 안됩니다. 누구든 svg가 잘 적용되는 샘플을 하나 올려주시면 비슷하게 따라해볼 수 있을 것 같습니다.

3. 리팩토링 도와주세요! 스토리북 인덱싱 화면에 .map() 적용
파운데이션 제작시 .map()을 잘 굴렸습니다만, 이번 checkbox는 애매하더라구요. 뽀잉님 button도 그렇고.. 저렇게 일일히 다 넣는 방법 말고 있을 것 같아서요.
<Checkbox size="sm" colorScheme="pink" isChecked={false} isDisabled={false} isIndeterminate={false} text={chkText} />에서 colorScheme="pink"을 문자열로 받아오는데, 윗부분에 필요한 컬러만 const colorSchemeIndex = ['blue', 'teal', 'green', 'cyan', 'purple', 'pink']로 만들었고 이걸 적용하면 120라인이 20줄이면 될 것 같습니다.