### PR TITLE
add: Modal, fix: CloseButton

### DIFF
--- a/packages/chakra-ui-styled/src/components/form/button/Button.tsx
+++ b/packages/chakra-ui-styled/src/components/form/button/Button.tsx
@@ -9,6 +9,7 @@ export interface ButtonProps {
   children?: string;
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;
+  onClick?: () => void;
 }
 const setIcon = (icon: React.ReactNode) => {
   return <figure className="icon">{icon}</figure>;
@@ -21,10 +22,11 @@ const Button = ({
   colorScheme,
   leftIcon,
   rightIcon,
-  children
+  children,
+  onClick
 }: ButtonProps) => {
   return (
-    <StyleButton as={as} size={size} colorScheme={colorScheme} variant={variant}>
+    <StyleButton as={as} size={size} colorScheme={colorScheme} variant={variant} onClick={onClick}>
       {leftIcon && setIcon(leftIcon)}
       {children && (
         <StyleText size={size} weight="semibold">

--- a/packages/chakra-ui-styled/src/components/form/closebutton/CloseButton.styled.tsx
+++ b/packages/chakra-ui-styled/src/components/form/closebutton/CloseButton.styled.tsx
@@ -1,10 +1,7 @@
 export const CloseIconStyle = () => {
   return (
     <svg width="currentSize" height="currentSize" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path
-        d="M6 4.66688L10.6669 0L12 1.33312L7.33312 6L12 10.6669L10.6669 12L6 7.33312L1.33312 12L0 10.6669L4.66688 6L0 1.33312L1.33312 0L6 4.66688Z"
-        fill="currentColor"
-      />
+      <path d="M12 10.8891L15.8891 7L17 8.11094L13.1109 12L17 15.8891L15.8891 17L12 13.1109L8.11094 17L7 15.8891L10.8891 12L7 8.11094L8.11094 7L12 10.8891Z" fill="currentColor"/>
     </svg>
   );
 };

--- a/packages/chakra-ui-styled/src/components/form/closebutton/CloseButton.tsx
+++ b/packages/chakra-ui-styled/src/components/form/closebutton/CloseButton.tsx
@@ -10,9 +10,6 @@ const setIcon = (icon: React.ReactNode) => {
   return <figure className="icon">{icon}</figure>;
 };
 const CloseButtonStyle = styled.div<CloseButtonProps>`
-  display: flex;
-  align-items: center;
-  justify-content: center;
   width: ${({ size }) => ViewBoxSize[size]}px;
   height: ${({ size }) => ViewBoxSize[size]}px;
   aspect-ratio: 1;

--- a/packages/chakra-ui-styled/src/components/form/closebutton/CloseButton.tsx
+++ b/packages/chakra-ui-styled/src/components/form/closebutton/CloseButton.tsx
@@ -4,6 +4,7 @@ export interface CloseButtonProps {
   size: 'sm' | 'md' | 'lg';
   icon?: React.ReactNode;
   onClick?: () => void;
+  className?: string;
 }
 const ViewBoxSize = { sm: 24, md: 32, lg: 40 };
 const setIcon = (icon: React.ReactNode) => {
@@ -15,9 +16,9 @@ const CloseButtonStyle = styled.div<CloseButtonProps>`
   aspect-ratio: 1;
   cursor: pointer;
 `;
-const CloseButton = ({ size = 'sm', icon, onClick }: CloseButtonProps) => {
+const CloseButton = ({ size = 'sm', icon, className, onClick }: CloseButtonProps) => {
   return (
-  <CloseButtonStyle size={size} onClick={onClick}>
+  <CloseButtonStyle size={size} onClick={onClick} className={className}>
     {icon && setIcon(icon)}
   </CloseButtonStyle>
   )

--- a/packages/chakra-ui-styled/src/components/form/closebutton/CloseButton.tsx
+++ b/packages/chakra-ui-styled/src/components/form/closebutton/CloseButton.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 export interface CloseButtonProps {
   size: 'sm' | 'md' | 'lg';
   icon?: React.ReactNode;
+  onClick?: () => void;
 }
 const ViewBoxSize = { sm: 24, md: 32, lg: 40 };
 const setIcon = (icon: React.ReactNode) => {
@@ -17,9 +18,9 @@ const CloseButtonStyle = styled.div<CloseButtonProps>`
   aspect-ratio: 1;
   cursor: pointer;
 `;
-const CloseButton = ({ size = 'sm', icon }: CloseButtonProps) => {
+const CloseButton = ({ size = 'sm', icon, onClick }: CloseButtonProps) => {
   return (
-  <CloseButtonStyle size={size}>
+  <CloseButtonStyle size={size} onClick={onClick}>
     {icon && setIcon(icon)}
   </CloseButtonStyle>
   )

--- a/packages/chakra-ui-styled/src/components/overlay/modal/Modal.stories.tsx
+++ b/packages/chakra-ui-styled/src/components/overlay/modal/Modal.stories.tsx
@@ -10,10 +10,12 @@ export default {
   argTypes: {
     title: { control: { type: 'text' } },
     contents: { control: { type: 'text' } },
+    isOpen: { control: { type: 'boolean' } }
   },
   args: {
     title: 'Modal Title',
     contents: 'Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi. Mollit officia cillum Lorem ullamco minim nostrud elit officia tempor esse quis.',
+    isOpen: false
   }
 };
 const Wrapper = styled.div`

--- a/packages/chakra-ui-styled/src/components/overlay/modal/Modal.stories.tsx
+++ b/packages/chakra-ui-styled/src/components/overlay/modal/Modal.stories.tsx
@@ -8,8 +8,12 @@ export default {
   parameters: { controls: { expanded: true } },
 
   argTypes: {
+    title: { control: { type: 'text' } },
+    contents: { control: { type: 'text' } },
   },
   args: {
+    title: 'Modal Title',
+    contents: 'Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi. Mollit officia cillum Lorem ullamco minim nostrud elit officia tempor esse quis.',
   }
 };
 const Wrapper = styled.div`
@@ -31,8 +35,6 @@ export const ModalIndex = (args: ModalProps) => {
       <Wrap>
         <Modal {...args} />
       </Wrap>
-
-      <h2>Modal Index</h2>
     </Wrapper>
   );
 };

--- a/packages/chakra-ui-styled/src/components/overlay/modal/Modal.stories.tsx
+++ b/packages/chakra-ui-styled/src/components/overlay/modal/Modal.stories.tsx
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+import Modal, { ModalProps } from './Modal';
+
+
+export default {
+  title: 'chakra-ui-styled/components/overlay/modal',
+  component: Modal,
+  parameters: { controls: { expanded: true } },
+
+  argTypes: {
+  },
+  args: {
+  }
+};
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+const Wrap = styled.div`
+  display: inline-flex;
+  padding: 50px 80px;
+`;
+
+export const ModalIndex = (args: ModalProps) => {
+  return (
+    <Wrapper>
+      <h1>Modal</h1>
+
+      <h2>Modal Demo</h2>
+      <Wrap>
+        <Modal {...args} />
+      </Wrap>
+
+      <h2>Modal Index</h2>
+    </Wrapper>
+  );
+};
+ModalIndex.storyName = 'Modal';

--- a/packages/chakra-ui-styled/src/components/overlay/modal/Modal.styled.tsx
+++ b/packages/chakra-ui-styled/src/components/overlay/modal/Modal.styled.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+import CloseButton from '../../form/closebutton/CloseButton';
+import Button from '../../form/button/Button';
+import { ModalProps } from './Modal';
+
+export const StyleModal = styled.div``;
+export const ModalOverlay = styled.div``;
+export const ModalContent = styled.div``;
+export const ModalHeader = styled.div``;
+export const ModalCloseButton = styled.div``;
+export const ModalBody = styled.div``;
+export const ModalFooter = styled.div``;

--- a/packages/chakra-ui-styled/src/components/overlay/modal/Modal.styled.tsx
+++ b/packages/chakra-ui-styled/src/components/overlay/modal/Modal.styled.tsx
@@ -1,14 +1,8 @@
-import styled, { css } from 'styled-components';
-import CloseButton, { CloseButtonProps } from '../../form/closebutton/CloseButton';
-
+import styled from 'styled-components';
+import CloseButton from '../../form/closebutton/CloseButton';
 
 export const StyleModal = styled.div<{ isOpen: boolean }>`
-  display: none;
-  ${({ isOpen }) =>
-    isOpen &&
-    css`
-        display: block;
-    `}
+  display: ${({ isOpen }) => (isOpen ? 'flex' : 'none')};
 `;
 export const ModalOverlay = styled.div`
   position: fixed;
@@ -29,6 +23,7 @@ export const ModalContent = styled.div`
   box-shadow: 0px 4px 6px -2px rgba(0,0,0,0.05), 0px 10px 15px -3px rgba(0,0,0,0.1);
   min-width: 448px;
   z-index: 110;
+  
 `;
 export const ModalHeader = styled.div`
   display: flex;
@@ -36,16 +31,6 @@ export const ModalHeader = styled.div`
   padding: 16px 24px;
   width: 100%;
   ${({ theme }) => theme.typo.text.lg};
-`;
-const ExternalButton = ({ onClick }: CloseButtonProps) => (
-    <CloseButton size={'md'} onClick={onClick}/>
-  );
-export const ModalCloseButton = styled(ExternalButton)`
-  cursor: pointer;
-  position: absolute;
-  top: 8px;
-  right: 16px;
-  z-index: 120;
 `;
 export const ModalBody = styled.div`
   padding: 8px 24px;
@@ -57,3 +42,8 @@ export const ModalFooter = styled.div`
   justify-content: flex-end;
   gap: 10px;
 `;
+export const StyledCloseButton = styled(CloseButton)`
+    position: absolute;
+    top: 8px;
+    right: 16px;
+  `

--- a/packages/chakra-ui-styled/src/components/overlay/modal/Modal.styled.tsx
+++ b/packages/chakra-ui-styled/src/components/overlay/modal/Modal.styled.tsx
@@ -1,12 +1,59 @@
-import styled from 'styled-components';
-import CloseButton from '../../form/closebutton/CloseButton';
-import Button from '../../form/button/Button';
-import { ModalProps } from './Modal';
+import styled, { css } from 'styled-components';
+import CloseButton, { CloseButtonProps } from '../../form/closebutton/CloseButton';
 
-export const StyleModal = styled.div``;
-export const ModalOverlay = styled.div``;
-export const ModalContent = styled.div``;
-export const ModalHeader = styled.div``;
-export const ModalCloseButton = styled.div``;
-export const ModalBody = styled.div``;
-export const ModalFooter = styled.div``;
+
+export const StyleModal = styled.div<{ isOpen: boolean }>`
+  display: none;
+  ${({ isOpen }) =>
+    isOpen &&
+    css`
+        display: block;
+    `}
+`;
+export const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: ${({ theme }) => theme.color.blackAlpha[600]};
+  z-index: 100;
+`;
+export const ModalContent = styled.div`
+  border-radius: 6px;
+  background-color: #fff;
+  position: absolute;
+  top: 40%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  box-shadow: 0px 4px 6px -2px rgba(0,0,0,0.05), 0px 10px 15px -3px rgba(0,0,0,0.1);
+  min-width: 448px;
+  z-index: 110;
+`;
+export const ModalHeader = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 16px 24px;
+  width: 100%;
+  ${({ theme }) => theme.typo.text.lg};
+`;
+const ExternalButton = ({ onClick }: CloseButtonProps) => (
+    <CloseButton size={'md'} onClick={onClick}/>
+  );
+export const ModalCloseButton = styled(ExternalButton)`
+  cursor: pointer;
+  position: absolute;
+  top: 8px;
+  right: 16px;
+  z-index: 120;
+`;
+export const ModalBody = styled.div`
+  padding: 8px 24px;
+  ${({ theme }) => theme.typo.text.md};
+`;
+export const ModalFooter = styled.div`
+  padding: 16px 24px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+`;

--- a/packages/chakra-ui-styled/src/components/overlay/modal/Modal.tsx
+++ b/packages/chakra-ui-styled/src/components/overlay/modal/Modal.tsx
@@ -1,0 +1,52 @@
+import { StyleModal,ModalOverlay,ModalContent,ModalHeader,ModalCloseButton, ModalBody, ModalFooter } from './Modal.styled';
+import { ReactNode } from 'react';
+import Button from '../../form/button/Button';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLImageElement> {
+  as?: React.ElementType;
+  size: 'lg' | 'md' | 'sm' | 'xs';
+  colorScheme: 'blue' | 'gray' | 'teal' | 'red' | 'orange' | 'yellow' | 'pink' | 'purple' | 'green';
+  variant?: 'solid' | 'outline';
+  children?: string;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+  onClick?: () => void;
+}
+export interface ModalProps {
+  // isOpen: boolean;
+  children?: ReactNode;
+}
+
+const Modal = ({ children }: ModalProps) => {
+// const Modal = ({ isOpen, children }: ModalProps) => {
+  
+  
+  const onOpen = ()=>{}
+  const onClose = ()=>{}
+  const ExtendButton: React.FunctionComponent<ButtonProps> = ({...rest}) => {
+    return <Button {...rest} />;
+  };
+  return (
+    <>
+      <ExtendButton size={'md'} colorScheme={'gray'} onClick={onOpen}>Open Modal</ExtendButton>
+
+      <StyleModal>
+      {/* <StyleModal isOpen={isOpen} onClose={onClose}> */}
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader> {children} </ModalHeader>
+          <ModalCloseButton />
+          
+          <ModalBody> {children} </ModalBody>
+
+          <ModalFooter>
+            <ExtendButton size={'md'} colorScheme={'blue'} onClick={onClose}>
+              Close
+            </ExtendButton>
+          </ModalFooter>
+        </ModalContent>
+      </StyleModal>
+    </>
+  )
+}
+export default Modal;

--- a/packages/chakra-ui-styled/src/components/overlay/modal/Modal.tsx
+++ b/packages/chakra-ui-styled/src/components/overlay/modal/Modal.tsx
@@ -1,53 +1,53 @@
-import { StyleModal, ModalOverlay, ModalContent, ModalHeader, StyledCloseButton, ModalBody, ModalFooter } from './Modal.styled';
+import {
+  StyleModal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  StyledCloseButton,
+  ModalBody,
+  ModalFooter
+} from './Modal.styled';
 import { useState } from 'react';
 import Button from '../../form/button/Button';
-import { CloseIconStyle } from '../../form/closebutton/CloseButton.styled'
+import { CloseIconStyle } from '../../form/closebutton/CloseButton.styled';
 
-interface ButtonProps extends React.ButtonHTMLAttributes<HTMLImageElement> {
-  as?: React.ElementType;
-  size: 'lg' | 'md' | 'sm' | 'xs';
-  colorScheme: 'blue' | 'gray' | 'teal' | 'red' | 'orange' | 'yellow' | 'pink' | 'purple' | 'green';
-  variant?: 'solid' | 'outline';
-  children?: string;
-  leftIcon?: React.ReactNode;
-  rightIcon?: React.ReactNode;
-  onClick?: () => void;
-  // 클릭기능을 확장하려 했으나 반영이 되지 않음
-}
 export interface ModalProps {
-  isOpen: boolean,
+  isOpen: boolean;
   title?: string;
   contents?: string;
 }
 
 const Modal = ({ isOpen, title, contents }: ModalProps) => {
   const [modalIsOpen, setModalIsOpen] = useState(isOpen);
-  const openModal = ()=> setModalIsOpen(true);
-  const closeModal = ()=> setModalIsOpen(false);
-  
-  const ExtendButton: React.FunctionComponent<ButtonProps> = ({...rest}) => {
-    return <Button {...rest} />;
-  };
+  const openModal = () => setModalIsOpen(true);
+  const closeModal = () => setModalIsOpen(false);
+
   return (
     <>
-      <button onClick={openModal}>임시버튼</button>
-      <ExtendButton size={'md'} colorScheme={'gray'} onClick={openModal}> Open Modal </ExtendButton>
-      
+      {/* <button onClick={openModal}>임시버튼</button> */}
+      <Button size={'md'} colorScheme={'gray'} onClick={openModal}>
+        Open Modal
+      </Button>
+
       <StyleModal isOpen={modalIsOpen}>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader> {title} </ModalHeader>
-          <StyledCloseButton size={'md'} onClick={closeModal} icon={<CloseIconStyle />}/>
-          
+          <StyledCloseButton size={'md'} onClick={closeModal} icon={<CloseIconStyle />} />
+
           <ModalBody> {contents} </ModalBody>
 
           <ModalFooter>
-            <ExtendButton size={'md'} colorScheme={'blue'} onClick={closeModal}> Close </ExtendButton>
-            <ExtendButton size={'md'} colorScheme={'gray'} onClick={closeModal}> Cancel </ExtendButton>
+            <Button size={'md'} colorScheme={'blue'} onClick={closeModal}>
+              Close
+            </Button>
+            <Button size={'md'} colorScheme={'gray'} onClick={closeModal}>
+              Cancel
+            </Button>
           </ModalFooter>
         </ModalContent>
       </StyleModal>
     </>
-  )
-}
+  );
+};
 export default Modal;

--- a/packages/chakra-ui-styled/src/components/overlay/modal/Modal.tsx
+++ b/packages/chakra-ui-styled/src/components/overlay/modal/Modal.tsx
@@ -1,5 +1,5 @@
-import { StyleModal,ModalOverlay,ModalContent,ModalHeader,ModalCloseButton, ModalBody, ModalFooter } from './Modal.styled';
-import { ReactNode } from 'react';
+import { StyleModal, ModalOverlay, ModalContent, ModalHeader, ModalCloseButton, ModalBody, ModalFooter } from './Modal.styled';
+import { useState } from 'react';
 import Button from '../../form/button/Button';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLImageElement> {
@@ -13,36 +13,35 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLImageElement> {
   onClick?: () => void;
 }
 export interface ModalProps {
-  // isOpen: boolean;
-  children?: ReactNode;
+  title?: string;
+  contents?: string;
 }
 
-const Modal = ({ children }: ModalProps) => {
-// const Modal = ({ isOpen, children }: ModalProps) => {
+const Modal = ({ title, contents }: ModalProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const onOpen = ()=> {setIsOpen(true)};
+  const onClose = ()=> {setIsOpen(false)};
   
   
-  const onOpen = ()=>{}
-  const onClose = ()=>{}
   const ExtendButton: React.FunctionComponent<ButtonProps> = ({...rest}) => {
     return <Button {...rest} />;
   };
+
   return (
     <>
-      <ExtendButton size={'md'} colorScheme={'gray'} onClick={onOpen}>Open Modal</ExtendButton>
-
-      <StyleModal>
-      {/* <StyleModal isOpen={isOpen} onClose={onClose}> */}
+      <ExtendButton size={'md'} colorScheme={'gray'} onClick={onOpen}> Open Modal </ExtendButton>
+      
+      <StyleModal isOpen={isOpen}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader> {children} </ModalHeader>
-          <ModalCloseButton />
+          <ModalHeader> {title} </ModalHeader>
+          <ModalCloseButton size={'md'} onClick={onClose}/>
           
-          <ModalBody> {children} </ModalBody>
+          <ModalBody> {contents} </ModalBody>
 
           <ModalFooter>
-            <ExtendButton size={'md'} colorScheme={'blue'} onClick={onClose}>
-              Close
-            </ExtendButton>
+            <ExtendButton size={'md'} colorScheme={'blue'} onClick={onClose}> Close </ExtendButton>
+            <ExtendButton size={'md'} colorScheme={'gray'} > Cancel </ExtendButton>
           </ModalFooter>
         </ModalContent>
       </StyleModal>

--- a/packages/chakra-ui-styled/src/components/overlay/modal/Modal.tsx
+++ b/packages/chakra-ui-styled/src/components/overlay/modal/Modal.tsx
@@ -1,6 +1,7 @@
-import { StyleModal, ModalOverlay, ModalContent, ModalHeader, ModalCloseButton, ModalBody, ModalFooter } from './Modal.styled';
+import { StyleModal, ModalOverlay, ModalContent, ModalHeader, StyledCloseButton, ModalBody, ModalFooter } from './Modal.styled';
 import { useState } from 'react';
 import Button from '../../form/button/Button';
+import { CloseIconStyle } from '../../form/closebutton/CloseButton.styled'
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLImageElement> {
   as?: React.ElementType;
@@ -11,37 +12,38 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLImageElement> {
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;
   onClick?: () => void;
+  // 클릭기능을 확장하려 했으나 반영이 되지 않음
 }
 export interface ModalProps {
+  isOpen: boolean,
   title?: string;
   contents?: string;
 }
 
-const Modal = ({ title, contents }: ModalProps) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const onOpen = ()=> {setIsOpen(true)};
-  const onClose = ()=> {setIsOpen(false)};
-  
+const Modal = ({ isOpen, title, contents }: ModalProps) => {
+  const [modalIsOpen, setModalIsOpen] = useState(isOpen);
+  const openModal = ()=> setModalIsOpen(true);
+  const closeModal = ()=> setModalIsOpen(false);
   
   const ExtendButton: React.FunctionComponent<ButtonProps> = ({...rest}) => {
     return <Button {...rest} />;
   };
-
   return (
     <>
-      <ExtendButton size={'md'} colorScheme={'gray'} onClick={onOpen}> Open Modal </ExtendButton>
+      <button onClick={openModal}>임시버튼</button>
+      <ExtendButton size={'md'} colorScheme={'gray'} onClick={openModal}> Open Modal </ExtendButton>
       
-      <StyleModal isOpen={isOpen}>
+      <StyleModal isOpen={modalIsOpen}>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader> {title} </ModalHeader>
-          <ModalCloseButton size={'md'} onClick={onClose}/>
+          <StyledCloseButton size={'md'} onClick={closeModal} icon={<CloseIconStyle />}/>
           
           <ModalBody> {contents} </ModalBody>
 
           <ModalFooter>
-            <ExtendButton size={'md'} colorScheme={'blue'} onClick={onClose}> Close </ExtendButton>
-            <ExtendButton size={'md'} colorScheme={'gray'} > Cancel </ExtendButton>
+            <ExtendButton size={'md'} colorScheme={'blue'} onClick={closeModal}> Close </ExtendButton>
+            <ExtendButton size={'md'} colorScheme={'gray'} onClick={closeModal}> Cancel </ExtendButton>
           </ModalFooter>
         </ModalContent>
       </StyleModal>


### PR DESCRIPTION
# 제목
feat : add: Modal, fix: CloseButton

## 변경 사항
- Modal추가
- CloseButton의 Props에 onClick과 styled-component에서 스타일 개별 확장을 위해 className 추가
- CloseButton에 사용한 svg  path가 좌상단에 정렬되어있어 path 수정

## 리뷰어 참고 사항
- 오탈자 및 컨벤션 맞는지 확인해주세요.

## 추가 참고 사항
- 버튼 컴포넌트에 onClick이 구현이 안되서 임시버튼으로 isOpen 상태 반영 하였습니다. 나중에 추가해 주세요
